### PR TITLE
clicking outside the modal should dismiss it

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -119,8 +119,18 @@ const App = () => {
     <div
       className="task-container flex justify-center border border-black"
       tabIndex={-1}
+      style={{width: '100%', height: '100vh'}}
+      onClick={(e) => {
+        logseq.hideMainUI({restoreEditingCursor: true});
+      }}
     >
-      <div className=" absolute top-10 bg-white rounded-lg p-3 w-1/3 border flex flex-col">
+      <div
+        className=" absolute top-10 bg-white rounded-lg p-3 border flex flex-col"
+        style={{minWidth: '33%'}}
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+      >
         <label
           htmlFor="toggle-example"
           className="flex items-center cursor-pointer relative mb-4"


### PR DESCRIPTION
Now, clicking outside the modal is captured by the outermost div, and dismisses the modal. 