### PR TITLE
Add `preferredWorkflow` to settings, and fix issue with its setup.

### DIFF
--- a/src/callSettings.ts
+++ b/src/callSettings.ts
@@ -18,6 +18,14 @@ export const callSettings = () => {
         "Default block in the Daily Notes Page to send tasks or items to. This block must exist or the item will be added to the bottom of the page. If more than one block of the same name exists, there will be an error message.",
       title: "Default Block",
     },
+    {
+      key: "preferredWorkflow",
+      type: "string",
+      default: "NOW",
+      description:
+        "What new tasks should be created as (either NOW, or TODO).",
+      title: "Preferred Workflow for New Tasks",
+    },
   ];
   logseq.useSettingsSchema(settings);
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,13 +17,7 @@ const main = () => {
 
   // Get preferred date format
   window.setTimeout(async () => {
-    const userConfigs = await logseq.App.getUserConfigs();
-    const preferredDateFormat: string = userConfigs.preferredDateFormat;
-    const preferredWorkflow: string = userConfigs.preferredWorkflow;
-    logseq.updateSettings({
-      preferredDateFormat: preferredDateFormat,
-      preferredWorkflow: preferredWorkflow,
-    });
+    const { preferredDateFormat, preferredWorkflow } = logseq.settings;
 
     if (!logseq.settings!.appendTodo) {
       logseq.updateSettings({


### PR DESCRIPTION
This patch adds the `preferredWorkflow` option to the plugin settings. It also fixes an issue where the setting was being overridden by the defaults, and the user setting was never used.